### PR TITLE
feat: support for `x86_64-apple-darwin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
           - os: macos-15
+            target: x86_64-apple-darwin
+          - os: macos-15
             target: aarch64-apple-darwin
           - os: windows-2025
             target: x86_64-pc-windows-msvc

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The tier system does not imply stability, but rather indicates the priority of a
 
 - `aarch64-unknown-linux-gnu`
 - `aarch64-unknown-linux-musl`
+- `x86_64-apple-darwin`
 - `aarch64-apple-darwin`
 - `aarch64-pc-windows-msvc`
 


### PR DESCRIPTION
This target will be supported for the next 3 years, so it is necessary.