### PR TITLE
simplify code for --help a bit

### DIFF
--- a/cli/src/flag.rs
+++ b/cli/src/flag.rs
@@ -32,21 +32,16 @@ pub fn parse_args() -> CliArgs {
 /// Print help message for a specific command
 pub fn print_help(command: Option<&str>) {
     let parser = cli_parser();
+    let args = match command {
+        Some(c) => &[c, "--help"][..],
+        None => &["--help"][..],
+    };
 
-    if let Some(cmd) = command {
-        // Print help for specific command by simulating args
-        let help_args = vec![cmd.to_string(), "--help".to_string()];
-        let args = Args::from(help_args.as_slice()).set_name("mdeno");
-        if let Err(err) = parser.run_inner(args) {
-            err.print_message(80);
-        }
-    } else {
-        // Print main help by simulating --help arg
-        let help_args = vec!["--help".to_string()];
-        let args = Args::from(help_args.as_slice()).set_name("mdeno");
-        if let Err(err) = parser.run_inner(args) {
-            err.print_message(80);
-        }
+    // Print help for specific command by simulating args
+
+    let args = Args::from(args).set_name("mdeno");
+    if let Err(err) = parser.run_inner(args) {
+        err.print_message(80);
     }
 }
 

--- a/cli/src/flag.rs
+++ b/cli/src/flag.rs
@@ -54,6 +54,7 @@ fn cli_parser() -> OptionParser<CliArgs> {
     let run_file = positional::<String>("FILE").help("File to run");
     let run_args = positional::<String>("ARGS")
         .help("Arguments to pass to the script (use -- to separate)")
+        .strict()
         .many();
     let run = construct!(unstable_flag(), run_file, run_args)
         .map(|(unstable, file_path, script_args)| CliArgs {


### PR DESCRIPTION
Branches seem to be doing the same with only difference beoing contents
of a vector. Factor it out. Args can be constructed from all sorts of
things so might as well avoid allocating at this point.
